### PR TITLE
Add links to repo and docs from README and docs frontpage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,3 +7,6 @@
 This package contains sphinxcontrb.datatemplates, an extension for
 Sphinx to render parts of reStructuredText pages from data files in
 formats like JSON, YAML, and CSV.
+
+* Repo: https://github.com/dhellmann/sphinxcontrib.datatemplates
+* Docs: http://sphinxcontribdatatemplates.readthedocs.io/

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,6 +7,9 @@ readable format in your documentation by letting you define Jinja2
 templates to turn JSON or YAML data structures into reStructuredText
 for Sphinx to render as part of its output.
 
+* Repo: https://github.com/dhellmann/sphinxcontrib.datatemplates
+* Docs: http://sphinxcontribdatatemplates.readthedocs.io/
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
I found the repo and didn't see any docs. Almost gave up.

Then ✨  🍰  I found http://sphinxcontribdatatemplates.readthedocs.io with Google.

Adding links to repo and docs to the README and docs frontpage should help.

Note that at https://github.com/dhellmann/sphinxcontrib.datatemplates you can also add a URL.
IMO putting the link to the docs there also would be helpful ... most projects on GH do it.