### PR TITLE
Make rendering more powerful by including HTML context and arbitrary key

### DIFF
--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -19,6 +19,9 @@ source and the rendering template. It requires two parameters.
    ``include_env``
       **Optional**: A flag that includes the ``env`` from your Sphinx in the _template_ rendering context.
 
+   ``include_context``
+      **Optional**: A flag that includes the ``env.app.config.html_context`` from your Sphinx in the _template_ rendering context. This could overwrite existing template context!
+
 Template Context
 ================
 
@@ -35,8 +38,15 @@ If you set ``:key: foo`` on the directive,
 you will have a top-level ``key`` variable.
 This can be used to render a subset of the data in the template.
 
+If you set `:include_context:` on the directive,
+your template have the full ``env.app.config.html_context`` injected at the top-level.
+This allows you to maintain Jinja templates that work for both rendering in normal Sphinx builds,
+and within datatemplates.
+
 If you set `:include_env:` on the directive,
-you template will also have access to the builder's ``env`` while rendering.
+your template will also have access to the builder's ``env`` while rendering.
+This gives you more flexibility,
+but is not as user friendly as `:include_context:`.
 
 An example would look like::
 
@@ -44,7 +54,7 @@ An example would look like::
        :source: all-videos.yaml
        :template: video-listing.jinja
        :key: keynote-1
-       :include_env:
+       :include_context:
 
 
 Template Helpers

--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -16,8 +16,8 @@ source and the rendering template. It requires two parameters.
    ``key``
       **Optional**: A specific data key to pass to the template, so you can render a subset of the data.
 
-   ``include_context``
-      **Optional**: A flag that includes the ``html_context`` from your normal build in the _template_ rendering context.
+   ``include_env``
+      **Optional**: A flag that includes the ``env`` from your Sphinx in the _template_ rendering context.
 
 Template Context
 ================
@@ -31,13 +31,12 @@ template. No pre-processing is done on the data, so the template needs
 to handle aspects like ``None`` values and fields that have values
 that may interfere with parsing reStructuredText.
 
-If you set `:key: any_key` on the directive,
+If you set ``:key: foo`` on the directive,
 you will have a top-level ``key`` variable.
 This can be used to render a subset of the data in the template.
 
-If you set `:include_context:` on the directive,
-you template will also have access to the builder's ``html_context`` while rendering.
-This will be in the global template context, not inside ``data``.
+If you set `:include_env:` on the directive,
+you template will also have access to the builder's ``env`` while rendering.
 
 An example would look like::
 
@@ -45,7 +44,7 @@ An example would look like::
        :source: all-videos.yaml
        :template: video-listing.jinja
        :key: keynote-1
-       :include_context:
+       :include_env:
 
 
 Template Helpers

--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -13,6 +13,12 @@ source and the rendering template. It requires two parameters.
    ``template``
       The name of a template file on the Sphinx template search path.
 
+   ``key``
+      **Optional**: A specific data key to pass to the template, so you can render a subset of the data.
+
+   ``include_context``
+      **Optional**: A flag that includes the ``html_context`` from your normal build in the _template_ rendering context.
+
 Template Context
 ================
 
@@ -24,6 +30,23 @@ The data is loaded from the source and passed directly to the
 template. No pre-processing is done on the data, so the template needs
 to handle aspects like ``None`` values and fields that have values
 that may interfere with parsing reStructuredText.
+
+If you set `:key: any_key` on the directive,
+you will have a top-level ``key`` variable.
+This can be used to render a subset of the data in the template.
+
+If you set `:include_context:` on the directive,
+you template will also have access to the builder's ``html_context`` while rendering.
+This will be in the global template context, not inside ``data``.
+
+An example would look like::
+
+    .. datatemplate::
+       :source: all-videos.yaml
+       :template: video-listing.jinja
+       :key: keynote-1
+       :include_context:
+
 
 Template Helpers
 ================

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -15,7 +15,7 @@ class DataTemplate(rst.Directive):
         'source': rst.directives.unchanged,
         'template': rst.directives.unchanged,
         'key': rst.directives.unchanged,
-        'include_context': rst.directives.flag,
+        'include_env': rst.directives.flag,
     }
     has_content = False
 
@@ -63,18 +63,13 @@ class DataTemplate(rst.Directive):
             return [error]
 
         key = self.options.get('key')
-        include_context = self.options.get('include_context')
 
         data = self._load_data(env, data_source)
 
         context = {}
 
-        if include_context:
-            try:
-                context.update(app.builder.html_context)
-            except KeyError:
-                app.warn('`include_context` set, but builder has no `html_context`.')
-
+        if 'include_env' in self.options:
+            context.update({'env': env})
 
         context.update({
             'make_list_table': helpers.make_list_table,

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -16,6 +16,7 @@ class DataTemplate(rst.Directive):
         'template': rst.directives.unchanged,
         'key': rst.directives.unchanged,
         'include_env': rst.directives.flag,
+        'include_context': rst.directives.flag,
     }
     has_content = False
 
@@ -70,6 +71,14 @@ class DataTemplate(rst.Directive):
 
         if 'include_env' in self.options:
             context.update({'env': env})
+
+        if 'include_context' in self.options:
+            if 'html_context' in env.app.config:
+                context.update(**env.app.config.html_context)
+            else:
+                app.warn(
+                    'The builder has no html_context,'
+                    'ignoring the include_context directive.')
 
         context.update({
             'make_list_table': helpers.make_list_table,

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -14,6 +14,8 @@ class DataTemplate(rst.Directive):
     option_spec = {
         'source': rst.directives.unchanged,
         'template': rst.directives.unchanged,
+        'key': rst.directives.unchanged,
+        'include_context': rst.directives.flag,
     }
     has_content = False
 
@@ -60,14 +62,28 @@ class DataTemplate(rst.Directive):
                 line=self.lineno)
             return [error]
 
+        key = self.options.get('key')
+        include_context = self.options.get('include_context')
+
         data = self._load_data(env, data_source)
 
-        context = {
+        context = {}
+
+        if include_context:
+            try:
+                context.update(app.builder.html_context)
+            except KeyError:
+                app.warn('`include_context` set, but builder has no `html_context`.')
+
+
+        context.update({
             'make_list_table': helpers.make_list_table,
             'make_list_table_from_mappings':
                 helpers.make_list_table_from_mappings,
             'data': data,
-        }
+            'key': key,
+        })
+
         rendered_template = builder.templates.render(
             template_name,
             context,

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -58,6 +58,7 @@ class DataTemplate(rst.Directive):
                 app.info(
                     'No source set for datatemplate directive,',
                     'allowing because of other included context.')
+                data_source = ''
 
         try:
             template_name = self.options['template']
@@ -70,7 +71,10 @@ class DataTemplate(rst.Directive):
 
         key = self.options.get('key')
 
-        data = self._load_data(env, data_source)
+        if data_source:
+            data = self._load_data(env, data_source)
+        else:
+            data = {}
 
         context = {}
 

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -48,11 +48,16 @@ class DataTemplate(rst.Directive):
         try:
             data_source = self.options['source']
         except KeyError:
-            error = self.state_machine.reporter.error(
-                'No source set for datatemplate directive',
-                nodes.literal_block(self.block_text, self.block_text),
-                line=self.lineno)
-            return [error]
+            if not ('include_context' in self.options or 'include_env' in self.options):
+                error = self.state_machine.reporter.error(
+                    'No source set for datatemplate directive',
+                    nodes.literal_block(self.block_text, self.block_text),
+                    line=self.lineno)
+                return [error]
+            else:
+                app.info(
+                    'No source set for datatemplate directive,',
+                    'allowing because of other included context.')
 
         try:
             template_name = self.options['template']


### PR DESCRIPTION
This allows folks to get more powerful rendering out of their templates.
It adds:

If you set ``:key: foo`` on the directive,
you will have a top-level ``key`` variable.
This can be used to render a subset of the data in the template.

If you set `:include_context:` on the directive,
you template will also have access to the builder's ``html_context`` while rendering.
This will be in the global template context, not inside ``data``.