### PR TITLE
Use sphinx.util.logging for logging calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /AUTHORS
 /ChangeLog
 /*.egg-info/
+/*.eggs/
 /build/
 /doc/build/

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 # setuptools if some other modules registered functions in `atexit`.
 # solution from: http://bugs.python.org/issue15881#msg170215
 try:
-    import multiprocessing  # flake8: noqa
+    import multiprocessing  # noqa
 except ImportError:
     pass
 

--- a/sphinxcontrib/datatemplates/__init__.py
+++ b/sphinxcontrib/datatemplates/__init__.py
@@ -1,6 +1,10 @@
+from sphinx.util import logging
+
 from sphinxcontrib.datatemplates import directive
+
+LOG = logging.getLogger(__name__)
 
 
 def setup(app):
-    app.info('initializing sphinxcontrib.datatemplates')
+    LOG.info('initializing sphinxcontrib.datatemplates')
     app.add_directive('datatemplate', directive.DataTemplate)

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -3,10 +3,13 @@ import json
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.statemachine import ViewList
+from sphinx.util import logging
 from sphinx.util.nodes import nested_parse_with_titles
 import yaml
 
 from sphinxcontrib.datatemplates import helpers
+
+LOG = logging.getLogger(__name__)
 
 
 class DataTemplate(rst.Directive):
@@ -37,7 +40,7 @@ class DataTemplate(rst.Directive):
         # have the attribute set to None.
         templates = getattr(builder, 'templates', None)
         if not templates:
-            app.warn(
+            LOG.warn(
                 'The builder has no template manager, '
                 'ignoring the datatemplate directive.')
             return []


### PR DESCRIPTION
Using the app instance to log has been deprecated for some time and now 
removed in the recently release sphinx 2.0. This updates existing logging
calls to use the recommended sphinx.util.logging methods instead.

Closes #6