### PR TITLE
Split datatemplate directive by file type

### DIFF
--- a/doc/source/csv.rst
+++ b/doc/source/csv.rst
@@ -20,17 +20,17 @@ Code
 
 .. code-block:: rst
 
-    .. datatemplate::
+    .. datatemplate-csv::
         :source: sample.csv
         :template: csv-sample.tmpl
-        :csvheaders:
-        :csvdialect: excel-tab
+        :headers:
+        :dialect: excel-tab
 
 Rendered Output
 ===============
 
-    .. datatemplate::
-        :source: sample.csv
-        :template: csv-sample.tmpl
-        :csvheaders:
-        :csvdialect: excel-tab
+.. datatemplate-csv::
+    :source: sample.csv
+    :template: csv-sample.tmpl
+    :headers:
+    :dialect: excel-tab

--- a/doc/source/json.rst
+++ b/doc/source/json.rst
@@ -17,6 +17,6 @@ Template File
 Rendered Output
 ===============
 
-.. datatemplate::
+.. datatemplate-json::
    :source: sample.json
    :template: sample.tmpl

--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -5,23 +5,68 @@
 The ``datatemplate`` directive is the interface between the data
 source and the rendering template. It requires two parameters.
 
-.. rst:directive:: datatemplate
+.. rst:directive:: datatemplate-json
+    
+   Load ``source`` via :py:func:`json.load`
 
-   ``source``
-      The source file, relative to the documentation build directory.
+   .. rst:directive:option:: source: source path, required
 
-   ``template``
-      The name of a template file on the Sphinx template search path.
+        The source file, relative to the documentation build directory.
+
+   .. rst:directive:option:: template: template name, required
+
+        The name of a template file on the Sphinx template search path.
+
+.. rst:directive:: datatemplate-yaml
+    
+   Load ``source`` via PyYAML_ (``yaml.safe_load``)
+
+   .. rst:directive:option:: source: source path, required
+
+        The source file, relative to the documentation build directory.
+
+   .. rst:directive:option:: template: template name, required
+
+        The name of a template file on the Sphinx template search path.
+
+.. _PyYAML: https://pyyaml.org
+
+.. rst:directive:: datatemplate-xml
+    
+   Load ``source`` via :py:func:`xml.etree.ElementTree.parse` (actually using ``defusedxml``)
+
+   .. rst:directive:option:: source: source path, required
+
+        The source file, relative to the documentation build directory.
+
+   .. rst:directive:option:: template: template name, required
+
+        The name of a template file on the Sphinx template search path.
 
 
-   ``csvheader`` optional flag, CSV only
-      Set to use :py:class:`csv.DictReader` for reading the file.
-      If not set :py:func:`csv.reader` is used.
+.. rst:directive:: datatemplate-csv
+    
+   Load ``source`` via :py:func:`csv.reader` or :py:class:`csv.DictReader` depending on ``header``
 
-   ``csvdialect`` optional, CSV only, either ``auto`` or one from :py:func:`csv.list_dialects`
-      Set to select a specific :py:class:`csv.Dialect`.
-      Set to ``auto``, to try autodetection.
-      If not set the default dialect is used.
+   .. rst:directive:option:: source: source path, required
+
+        The source file, relative to the documentation build directory.
+
+   .. rst:directive:option:: template: template name, required
+
+        The name of a template file on the Sphinx template search path.
+
+   .. rst:directive:option:: header: flag, optional
+
+        Set to use :py:class:`csv.DictReader` for reading the file.
+        If not set :py:func:`csv.reader` is used.
+
+   .. rst:directive:option:: dialect: either ``auto`` or one from :py:func:`csv.list_dialects`, optional
+
+        Set to select a specific :py:class:`csv.Dialect`.
+        Set to ``auto``, to try autodetection.
+        If not set the default dialect is used.
+
 
 Template Context
 ================
@@ -30,29 +75,14 @@ When a ``datatemplate`` directive is processed, the data is passed to
 the template through its context so that the symbol ``data`` is
 available as a global variable.
 
-.. list-table::
-   :header-rows: 1
+.. important::
+    The data is loaded from the source and passed directly to the
+    template. No pre-processing is done on the data, so the template needs
+    to handle aspects like ``None`` values and fields that have values
+    that may interfere with parsing reStructuredText.
 
-   - * Format
-     * ``data`` type
-   - * JSON
-     * the object returned by ``json.safe_load()`` (varies based on
-       input)
-   - * YAML
-     * the object returned by the PyYAML_ function ``yaml.safe_load()``
-       (varies based on input)
-   - * XML
-     * :py:class:`xml.etree.ElementTree.ElementTree`
-   - * CSV
-     * ``list`` of ``tuple`` or ``dict`` (when ``csvheaders`` option
-       is specified)
 
-.. _PyYAML: https://pyyaml.org
 
-The data is loaded from the source and passed directly to the
-template. No pre-processing is done on the data, so the template needs
-to handle aspects like ``None`` values and fields that have values
-that may interfere with parsing reStructuredText.
 
 Template Helpers
 ================

--- a/doc/source/xml.rst
+++ b/doc/source/xml.rst
@@ -17,6 +17,6 @@ Template File
 Rendered Output
 ===============
 
-.. datatemplate::
+.. datatemplate-xml::
    :source: sample.xml
    :template: xml-sample.tmpl

--- a/doc/source/yaml.rst
+++ b/doc/source/yaml.rst
@@ -17,6 +17,6 @@ Template File
 Rendered Output
 ===============
 
-.. datatemplate::
+.. datatemplate-yaml::
    :source: sample.yaml
    :template: sample.tmpl

--- a/sphinxcontrib/datatemplates/__init__.py
+++ b/sphinxcontrib/datatemplates/__init__.py
@@ -7,4 +7,7 @@ LOG = logging.getLogger(__name__)
 
 def setup(app):
     LOG.info('initializing sphinxcontrib.datatemplates')
-    app.add_directive('datatemplate', directive.DataTemplate)
+    app.add_directive('datatemplate-json', directive.DataTemplateJSON)
+    app.add_directive('datatemplate-yaml', directive.DataTemplateYAML)
+    app.add_directive('datatemplate-csv', directive.DataTemplateCSV)
+    app.add_directive('datatemplate-xml', directive.DataTemplateXML)

--- a/sphinxcontrib/datatemplates/__init__.py
+++ b/sphinxcontrib/datatemplates/__init__.py
@@ -11,3 +11,4 @@ def setup(app):
     app.add_directive('datatemplate-yaml', directive.DataTemplateYAML)
     app.add_directive('datatemplate-csv', directive.DataTemplateCSV)
     app.add_directive('datatemplate-xml', directive.DataTemplateXML)
+    app.add_directive('datatemplate', directive.DataTemplateLegacy)

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -1,67 +1,30 @@
 import json
-import mimetypes
-import defusedxml.ElementTree as ET
+import csv
 
+import defusedxml.ElementTree as ET
+import yaml
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.statemachine import ViewList
 from sphinx.util import logging
 from sphinx.util.nodes import nested_parse_with_titles
-import csv
-import yaml
 
 from sphinxcontrib.datatemplates import helpers
 
 LOG = logging.getLogger(__name__)
 
 
-def _handle_dialect_option(argument):
-    return rst.directives.choice(argument, ["auto"] + csv.list_dialects())
-
-
-class DataTemplate(rst.Directive):
+class DataTemplateBase(rst.Directive):
 
     option_spec = {
-        'source': rst.directives.unchanged,
-        'template': rst.directives.unchanged,
-        'csvheaders': rst.directives.flag,
-        'csvdialect': _handle_dialect_option,
+        'source': rst.directives.unchanged_required,
+        'template': rst.directives.unchanged_required,
     }
     has_content = False
 
     def _load_data(self, env, data_source):
         rel_filename, filename = env.relfn2path(data_source)
-        if data_source.endswith('.yaml'):
-            with open(filename, 'r') as f:
-                return yaml.safe_load(f)
-        elif data_source.endswith('.json'):
-            with open(filename, 'r') as f:
-                return json.load(f)
-        elif data_source.endswith('.csv'):
-            with open(filename, 'r', newline='') as f:
-                dialect = self.options.get('csvdialect')
-                if dialect == "auto":
-                    sample = f.read(8192)
-                    f.seek(0)
-                    sniffer = csv.Sniffer()
-                    dialect = sniffer.sniff(sample)
-                if 'csvheaders' in self.options:
-                    if dialect is None:
-                        r = csv.DictReader(f)
-                    else:
-                        r = csv.DictReader(f, dialect=dialect)
-                else:
-                    if dialect is None:
-                        r = csv.reader(f)
-                    else:
-                        r = csv.reader(f, dialect=dialect)
-                return list(r)
-        elif "xml" in mimetypes.guess_type(data_source)[0]:
-            return ET.parse(filename).getroot()
-
-        else:
-            raise NotImplementedError('cannot load file type of %s' %
-                                      data_source)
+        raise NotImplementedError('cannot load file type of %s' % data_source)
 
     def run(self):
         env = self.state.document.settings.env
@@ -71,35 +34,19 @@ class DataTemplate(rst.Directive):
         # have the attribute set to None.
         templates = getattr(builder, 'templates', None)
         if not templates:
-            LOG.warn(
-                'The builder has no template manager, '
-                'ignoring the datatemplate directive.')
+            LOG.warn('The builder has no template manager, '
+                     'ignoring the datatemplate directive.')
             return []
 
-        try:
-            data_source = self.options['source']
-        except KeyError:
-            error = self.state_machine.reporter.error(
-                'No source set for datatemplate directive',
-                nodes.literal_block(self.block_text, self.block_text),
-                line=self.lineno)
-            return [error]
-
-        try:
-            template_name = self.options['template']
-        except KeyError:
-            error = self.state_machine.reporter.error(
-                'No template set for datatemplate directive',
-                nodes.literal_block(self.block_text, self.block_text),
-                line=self.lineno)
-            return [error]
+        data_source = self.options['source']
+        template_name = self.options['template']
 
         data = self._load_data(env, data_source)
 
         context = {
             'make_list_table': helpers.make_list_table,
             'make_list_table_from_mappings':
-                helpers.make_list_table_from_mappings,
+            helpers.make_list_table_from_mappings,
             'data': data,
         }
         rendered_template = builder.templates.render(
@@ -114,3 +61,56 @@ class DataTemplate(rst.Directive):
         node.document = self.state.document
         nested_parse_with_titles(self.state, result, node)
         return node.children
+
+
+class DataTemplateJSON(DataTemplateBase):
+    def _load_data(self, env, data_source):
+        rel_filename, filename = env.relfn2path(data_source)
+        with open(filename, 'r') as f:
+            return json.load(f)
+
+
+def _handle_dialect_option(argument):
+    return rst.directives.choice(argument, ["auto"] + csv.list_dialects())
+
+
+class DataTemplateCSV(DataTemplateBase):
+    option_spec = dict(
+        DataTemplateBase.option_spec, **{
+            'headers': rst.directives.flag,
+            'dialect': _handle_dialect_option,
+        })
+
+    def _load_data(self, env, data_source):
+        rel_filename, filename = env.relfn2path(data_source)
+        with open(filename, 'r', newline='') as f:
+            dialect = self.options.get('dialect')
+            if dialect == "auto":
+                sample = f.read(8192)
+                f.seek(0)
+                sniffer = csv.Sniffer()
+                dialect = sniffer.sniff(sample)
+            if 'headers' in self.options:
+                if dialect is None:
+                    r = csv.DictReader(f)
+                else:
+                    r = csv.DictReader(f, dialect=dialect)
+            else:
+                if dialect is None:
+                    r = csv.reader(f)
+                else:
+                    r = csv.reader(f, dialect=dialect)
+            return list(r)
+
+
+class DataTemplateYAML(DataTemplateBase):
+    def _load_data(self, env, data_source):
+        rel_filename, filename = env.relfn2path(data_source)
+        with open(filename, 'r') as f:
+            return yaml.safe_load(f)
+
+
+class DataTemplateXML(DataTemplateBase):
+    def _load_data(self, env, data_source):
+        rel_filename, filename = env.relfn2path(data_source)
+        return ET.parse(filename).getroot()

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -114,3 +114,10 @@ class DataTemplateXML(DataTemplateBase):
     def _load_data(self, env, data_source):
         rel_filename, filename = env.relfn2path(data_source)
         return ET.parse(filename).getroot()
+
+
+class DataTemplateLegacy(DataTemplateYAML):
+    def run(self):
+        LOG.warning('Using the datatemplate directive is deprecated. '
+                    'Please use one of the format-specific variants.')
+        return super().run()

--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -1,5 +1,6 @@
 import json
 import csv
+import mimetypes
 
 import defusedxml.ElementTree as ET
 import yaml
@@ -116,8 +117,99 @@ class DataTemplateXML(DataTemplateBase):
         return ET.parse(resolved_path).getroot()
 
 
-class DataTemplateLegacy(DataTemplateYAML):
+class DataTemplateLegacy(rst.Directive):
+
+    option_spec = {
+        'source': rst.directives.unchanged,
+        'template': rst.directives.unchanged,
+        'csvheaders': rst.directives.flag,
+        'csvdialect': _handle_dialect_option,
+    }
+    has_content = False
+
+    def _load_data(self, env, data_source):
+        rel_filename, filename = env.relfn2path(data_source)
+        if data_source.endswith('.yaml'):
+            with open(filename, 'r') as f:
+                return yaml.safe_load(f)
+        elif data_source.endswith('.json'):
+            with open(filename, 'r') as f:
+                return json.load(f)
+        elif data_source.endswith('.csv'):
+            with open(filename, 'r', newline='') as f:
+                dialect = self.options.get('csvdialect')
+                if dialect == "auto":
+                    sample = f.read(8192)
+                    f.seek(0)
+                    sniffer = csv.Sniffer()
+                    dialect = sniffer.sniff(sample)
+                if 'csvheaders' in self.options:
+                    if dialect is None:
+                        r = csv.DictReader(f)
+                    else:
+                        r = csv.DictReader(f, dialect=dialect)
+                else:
+                    if dialect is None:
+                        r = csv.reader(f)
+                    else:
+                        r = csv.reader(f, dialect=dialect)
+                return list(r)
+        elif "xml" in mimetypes.guess_type(data_source)[0]:
+            return ET.parse(filename).getroot()
+
+        else:
+            raise NotImplementedError('cannot load file type of %s' %
+                                      data_source)
+
     def run(self):
         LOG.warning('Using the datatemplate directive is deprecated. '
                     'Please use one of the format-specific variants.')
-        return super().run()
+        env = self.state.document.settings.env
+        app = env.app
+        builder = app.builder
+        # Some builders have no templates manager at all, and some
+        # have the attribute set to None.
+        templates = getattr(builder, 'templates', None)
+        if not templates:
+            LOG.warn('The builder has no template manager, '
+                     'ignoring the datatemplate directive.')
+            return []
+
+        try:
+            data_source = self.options['source']
+        except KeyError:
+            error = self.state_machine.reporter.error(
+                'No source set for datatemplate directive',
+                nodes.literal_block(self.block_text, self.block_text),
+                line=self.lineno)
+            return [error]
+
+        try:
+            template_name = self.options['template']
+        except KeyError:
+            error = self.state_machine.reporter.error(
+                'No template set for datatemplate directive',
+                nodes.literal_block(self.block_text, self.block_text),
+                line=self.lineno)
+            return [error]
+
+        data = self._load_data(env, data_source)
+
+        context = {
+            'make_list_table': helpers.make_list_table,
+            'make_list_table_from_mappings':
+            helpers.make_list_table_from_mappings,
+            'data': data,
+        }
+        rendered_template = builder.templates.render(
+            template_name,
+            context,
+        )
+
+        result = ViewList()
+        for line in rendered_template.splitlines():
+            result.append(line, data_source)
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, result, node)
+        return node.children


### PR DESCRIPTION
See #17 
Actually breaks compatibility. Should I add "datatemplate-yaml" as "datatemplate" for backwards compatibility?