### PR TITLE
 Use default template manager when the builder does not have one

### DIFF
--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -4,12 +4,13 @@ import defusedxml.ElementTree as ET
 import yaml
 import dbm
 import contextlib
-
 import mimetypes
 import codecs
+
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.statemachine import ViewList
+from sphinx.jinja2glue import BuiltinTemplateLoader
 from sphinx.util import logging
 from sphinx.util.nodes import nested_parse_with_titles
 
@@ -28,7 +29,7 @@ def _templates(builder):
 
     if not templates:
         if not _default_templates:
-            from sphinx.jinja2glue import BuiltinTemplateLoader
+            # Initialize default templates manager once
             _default_templates = BuiltinTemplateLoader()
             _default_templates.init(builder)
 

--- a/sphinxcontrib/datatemplates/domain.py
+++ b/sphinxcontrib/datatemplates/domain.py
@@ -20,3 +20,6 @@ class DataTemplateDomain(Domain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node,
                      contnode):
         return None
+
+    def merge_domaindata(self, docnames, otherdata):
+        pass


### PR DESCRIPTION
Instead of ignoring the `datatemplate` directive when the builder does not use a template manager, initialize a `sphinx.jinja2glue.BuiltinTemplateLoader` template manager and use that.

Used successfully for _latex_ and _confluence_ targets.

Also, added an empty [merge_domaindata](https://www.sphinx-doc.org/en/master/extdev/domainapi.html#sphinx.domains.Domain.merge_domaindata) method to the domain for parallel builds to continue working.