### PR TITLE
add travis job to check package settings with twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ jobs:
     - name: "Lint"
       install: pip install flake8
       script: flake8 -v sphinxcontrib setup.py
-
+    - name: "Check Package"
+      install: pip install twine
+      script: ./tools/check_package.sh

--- a/tools/check_package.sh
+++ b/tools/check_package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+
+python setup.py sdist
+twine check dist/*$(python setup.py --version)*


### PR DESCRIPTION
This used to be part of the linter job but was removed in the refactoring in #46 