### PR TITLE
clean up data loader registration

### DIFF
--- a/sphinxcontrib/datatemplates/loaders.py
+++ b/sphinxcontrib/datatemplates/loaders.py
@@ -21,7 +21,7 @@ class LoaderEntry:
 def loader_for_source(source, default=None):
     "Return the loader for the named source."
     for e in registered_loaders:
-        if e.match_source(source):
+        if e.match_source is not None and e.match_source(source):
             return e.loader
     return default
 
@@ -29,7 +29,7 @@ def loader_for_source(source, default=None):
 def loader_by_name(name, default=None):
     "Return the loader registered with the given name."
     for e in registered_loaders:
-        if e.name == name:
+        if e.match_source is not None and e.name == name:
             return e.loader
     return default
 
@@ -76,6 +76,7 @@ def data_source_loader(name, match_source=None):
     return wrap
 
 
+@data_source_loader("nodata")
 @contextlib.contextmanager
 def load_nodata(source, **options):
     yield None

--- a/sphinxcontrib/datatemplates/loaders.py
+++ b/sphinxcontrib/datatemplates/loaders.py
@@ -41,7 +41,7 @@ def mimetype_loader(name, mimetype):
         if not guess:
             return False
         return guess == mimetype
-    return append_loader(name, check_mimetype)
+    return data_source_loader(name, check_mimetype)
 
 
 def lenient_mimetype_loader(name, mimetype_fragment):
@@ -51,7 +51,7 @@ def lenient_mimetype_loader(name, mimetype_fragment):
         if not guess:
             return False
         return mimetype_fragment in guess
-    return append_loader(name, check_mimetype)
+    return data_source_loader(name, check_mimetype)
 
 
 def file_extension_loader(name, extensions):
@@ -59,10 +59,10 @@ def file_extension_loader(name, extensions):
     def check_ext(filename):
         return pathlib.Path(filename).suffix.lower() in set(
             e.lower() for e in extensions)
-    return append_loader(name, check_ext)
+    return data_source_loader(name, check_ext)
 
 
-def append_loader(name, match_source=None):
+def data_source_loader(name, match_source=None):
     """Add a named loader
 
     Add a named data loader with an optional function for matching to
@@ -142,7 +142,7 @@ def load_dbm(source, absolute_resolved_path, **options):
     return dbm.open(absolute_resolved_path, "r")
 
 
-@append_loader("import-module")
+@data_source_loader("import-module")
 @contextlib.contextmanager
 def load_import_module(source, **options):
     yield importlib.import_module(source)

--- a/sphinxcontrib/datatemplates/tests/test_loaders.py
+++ b/sphinxcontrib/datatemplates/tests/test_loaders.py
@@ -1,0 +1,31 @@
+from sphinxcontrib.datatemplates import loaders
+
+
+def test_lookup_json():
+    actual = loaders.loader_for_source('source.json')
+    assert actual == loaders.load_json
+
+
+def test_lookup_yaml():
+    actual = loaders.loader_for_source('source.yaml')
+    assert actual == loaders.load_yaml
+
+
+def test_lookup_yml():
+    actual = loaders.loader_for_source('source.yml')
+    assert actual == loaders.load_yaml
+
+
+def test_lookup_xml():
+    actual = loaders.loader_for_source('source.xml')
+    assert actual == loaders.load_xml
+
+
+def test_lookup_csv():
+    actual = loaders.loader_for_source('source.csv')
+    assert actual == loaders.load_csv
+
+
+def test_lookup_dbm():
+    actual = loaders.loader_for_source('source.dbm')
+    assert actual == loaders.load_dbm


### PR DESCRIPTION
Add separate registration functions for the different ways we look up
loaders (mimetype, extension, etc.).

Add tests for looking up the loaders by source name.

Addresses #24
Addresses #25