### PR TITLE
update requirement for sphinxcontrib.runcmd

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pbr # not just for setup
 Sphinx
 PyYAML
 defusedxml
-sphinxcontrib.runcmd
+sphinxcontrib-runcmd


### PR DESCRIPTION
Use the canonical name from pypi for sphinxcontrib-runcmd (note the
dash).  The version with a dot causes an issue where pkg_resources
cannot find sphinxcontrib.runcmd because the installed package name is
sphinxcontrib-runcmd.  I think this is caused because pypi has a
redirect on the 'dot' version.

https://pypi.org/project/sphinxcontrib.runcmd/