### PR TITLE
Added a resolve_any_xref() method to DataTemplateDomain

### DIFF
--- a/sphinxcontrib/datatemplates/domain.py
+++ b/sphinxcontrib/datatemplates/domain.py
@@ -19,10 +19,12 @@ class DataTemplateDomain(Domain):
     def get_objects(self):
         return []
 
-    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node,
+                    contnode):
         return None
     
-    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
+    def resolve_any_xref(self, env, fromdocname, builder, target, node,
+                    contnode):
         return []
 
     def merge_domaindata(self, docnames, otherdata):

--- a/sphinxcontrib/datatemplates/domain.py
+++ b/sphinxcontrib/datatemplates/domain.py
@@ -20,11 +20,11 @@ class DataTemplateDomain(Domain):
         return []
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node,
-                    contnode):
+                     contnode):
         return None
-    
+
     def resolve_any_xref(self, env, fromdocname, builder, target, node,
-                    contnode):
+                         contnode):
         return []
 
     def merge_domaindata(self, docnames, otherdata):

--- a/sphinxcontrib/datatemplates/domain.py
+++ b/sphinxcontrib/datatemplates/domain.py
@@ -19,9 +19,11 @@ class DataTemplateDomain(Domain):
     def get_objects(self):
         return []
 
-    def resolve_xref(self, env, fromdocname, builder, typ, target, node,
-                     contnode):
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         return None
+    
+    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
+        return []
 
     def merge_domaindata(self, docnames, otherdata):
         pass


### PR DESCRIPTION
According to Sphinx documentation of the [Domain class](https://www.sphinx-doc.org/en/master/extdev/domainapi.html#sphinx.domains.Domain.resolve_any_xref), we need to add a 
```python
resolve_any_xref(self, env: "BuildEnvironment", fromdocname: str, builder: "Builder",target: str, node: pending_xref, contnode: Element) -> List[Tuple[str, Element]]
``` 
to the `DataTemplateDomain` class.

If we do not add this method, we get the following warning when we use a *datatemplate* directive from a *markdown* file with the [myst-parser extension](https://myst-parser.readthedocs.io/en/latest/index.html):

    WARNING: Domain 'sphinxcontrib.datatemplates.domain::datatemplate' has not implemented a `resolve_any_xref` method [myst.domains]

Here is the full build output:
```
Running Sphinx v4.1.0
initializing sphinxcontrib.datatemplates
making output directory... done
myst v0.15.1: MdParserConfig(renderer='sphinx', commonmark_only=False, enable_extensions=['dollarmath'], dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', disable_syntax=[], url_schemes=['http', 'https', 'mailto', 'ftp'], heading_anchors=None, heading_slug_func=None, html_meta=[], footnote_transition=True, substitutions=[], sub_delimiters=['{', '}'], words_per_minute=200)
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 4 source files that are out of date
updating environment: [new config] 4 added, 0 changed, 0 removed
reading sources... [100%] pageB
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] pageB
WARNING: Domain 'sphinxcontrib.datatemplates.domain::datatemplate' has not implemented a `resolve_any_xref` method [myst.domains]
generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 3 warnings.
```