### PR TITLE
Produce error on non-existing attributes in jina2

### DIFF
--- a/sphinxcontrib/datatemplates/directive.py
+++ b/sphinxcontrib/datatemplates/directive.py
@@ -177,10 +177,17 @@ class DataTemplateBase(rst.Directive):
 
         with self.loader(**loader_options) as data:
             context = self._make_context(data, app.config, env)
-            rendered_template = render_function(
-                template,
-                context,
-            )
+            from jinja2 import StrictUndefined
+            old = env.app.builder.templates.environment.undefined
+            try:
+                env.app.builder.templates.environment.undefined = StrictUndefined
+
+                rendered_template = render_function(
+                    template,
+                    context,
+                )
+            finally:
+                env.app.builder.templates.environment.undefined = old
 
         result = ViewList()
         for line in rendered_template.splitlines():


### PR DESCRIPTION
If this change is made in conf.py, then HTML rendering will
fail. These errors should only be reported for datatemplates.

Is there a way to configure this from conf.py??

See also #84 