### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ classifier =
     Development Status :: 4 - Beta
     Environment :: Console
     Environment :: Web Environment
+    Framework :: Sphinx :: Extension
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).