### PR TITLE
unify list of packaging dependencies

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine pbr
+        pip install .[build]
     - name: Build sdist and wheel
       run: |
         python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ test = [
     "pytest",
     "beautifulsoup4",
 ]
+build = [
+    "build",
+    "twine",
+]
 
 [tools.setuptools]
 packages = [

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,7 @@ commands=
 
 [testenv:pkglint]
 deps=
-    build
-    twine
+    .[build]
     check-python-versions
 commands=
     python -m build


### PR DESCRIPTION
Make the tox pkglint job and the github action for publishing packages
use the same source for the list of dependencies.